### PR TITLE
Add ClaimImages class and integrate with ClaimRequest

### DIFF
--- a/WarrantyManagement.DAL/Data/Request/ClaimImages.cs
+++ b/WarrantyManagement.DAL/Data/Request/ClaimImages.cs
@@ -1,0 +1,11 @@
+﻿namespace WarrantyManagement.DAL.Data.Request
+{
+    public class ClaimImages
+    {
+        public string ImageUrl { get; set; }
+
+        public string? Description { get; set; }
+
+        public int OrderIndex { get; set; }
+    }
+}

--- a/WarrantyManagement.DAL/Data/Request/ClaimRequest.cs
+++ b/WarrantyManagement.DAL/Data/Request/ClaimRequest.cs
@@ -32,6 +32,8 @@ namespace WarrantyManagement.DAL.Data.Request
         [MinLength(1, ErrorMessage = "At least one part must be selected")]
         public List<PartItemRequest> PartItems { get; set; }
         public ClaimActionType ActionType { get; set; }
+
+        public List<ClaimImages> ClaimImages { get; set; }
     }
 
     public class PartItemRequest


### PR DESCRIPTION
A new `ClaimImages` class was introduced in the `WarrantyManagement.DAL.Data.Request` namespace. This class includes properties for `ImageUrl`, `Description`, and `OrderIndex` to manage image-related data.

The `ClaimRequest` class was updated to include a new `ClaimImages` property, allowing the association of multiple images with a claim.